### PR TITLE
에러 수정 - authentication(settings), as_view(views) to urls(as_view)

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -72,7 +72,11 @@ REST_FRAMEWORK = {
         # 'rest_framework.permissions.AllowAny', # 누구나 접근
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication',
-    )
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        # 'rest_framework.permissions.IsAuthenticated',
+        'rest_framework.permissions.AllowAny', # 누구나 접근
+    ),
 }
 
 MIDDLEWARE = [
@@ -161,6 +165,9 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+
+# JWT 토큰 만료 시간 설정
 
 SIMPLE_JWT = {
     'ALGORITHM': 'HS256',

--- a/player/urls.py
+++ b/player/urls.py
@@ -11,16 +11,19 @@ app_name = "player"
 
 urlpatterns = [
     # 회원가입
-    path("register/", RegisterView, name="register"),
+    # path("register/", RegisterView, name="register"),
+    path("register/", RegisterView.as_view(), name="register"),
 
     # 로그인
-    path('login/', Login, name='login'),
-
+    # path('login/', Login, name='login'),
+    path("login/", Login.as_view(), name="login"),
     # 로그아웃
-    path('logout/', Logout, name='logout'),
+    # path('logout/', Logout, name='logout'),
+    path('logout/', Logout.as_view(), name='logout'),
 
     # 회원 정보수정
-    path('update/', Update, name='update'),
+    # path('update/', Update, name='update'),
+    path('update/', Update.as_view(), name='update'),
 
     # 회원 탈퇴
     # path("<str:playerId>/", 기능, name="remove"),

--- a/player/views.py
+++ b/player/views.py
@@ -90,8 +90,8 @@ class UnregisterUserView(APIView):
         return Response({"message": "회원탈퇴가 완료되었습니다."}, status=status.HTTP_204_NO_CONTENT)
 
 
-RegisterView = RegisterView.as_view()
-Login = Login.as_view()
-Logout = Logout.as_view()
-Update = Update.as_view()
-UnregisterUserView = UnregisterUserView.as_view()
+# RegisterView = RegisterView.as_view()
+# Login = Login.as_view()
+# Logout = Logout.as_view()
+# Update = Update.as_view()
+# UnregisterUserView = UnregisterUserView.as_view()


### PR DESCRIPTION
일부 에러 수정.

settings.py :
```
('DEFAULT_PERMISSION_CLASSES': 신설.)
    'DEFAULT_PERMISSION_CLASSES': (
        'rest_framework.permissions.AllowAny', # 누구나 접근
    ),
```

views.py
해당 코드 urls.py 로 포함(이식).
```
# RegisterView = RegisterView.as_view()
# Login = Login.as_view()
# Logout = Logout.as_view()
# Update = Update.as_view()
# UnregisterUserView = UnregisterUserView.as_view()
```