### PR TITLE
Dockerfile 업데이트 사항 4가지

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM python:3.11.4-alpine3.18
 # 환경 변수 설정
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
+ENV PATH="/py/bin:$PATH"
 
 # Python 및 PostgreSQL에 필요한 시스템 패키지를 설치합니다.
 RUN apk update \
@@ -17,16 +18,30 @@ WORKDIR /app
 # 현재 디렉토리의 내용을 컨테이너의 /app에 복사합니다.
 COPY . /app
 
+# Python 가상 환경 설정
+RUN python -m venv /py
+
 # requirements.txt에 지정된 패키지를 설치합니다.
-RUN pip install -r requirements.txt
+RUN /py/bin/pip install --upgrade pip \
+    && /py/bin/pip install -r requirements.txt
+
+# 빌드에만 필요한 패키지를 제거합니다.
+RUN apk del gcc musl-dev
 
 # 디렉터리가 존재하는 경우에만 chmod 명령을 실행합니다.
 RUN if [ -d "/app/staticfiles" ]; then chmod -R 755 /app/staticfiles; fi
+
+# 비권한 사용자 생성
+RUN adduser \
+    --disabled-password \
+    --no-create-home \
+    django-user
+
+# 비권한 사용자로 전환
+USER django-user
 
 # 컨테이너 외부에서 8000 포트에 액세스할 수 있도록 합니다.
 EXPOSE 8000
 
 # Django 서버를 시작하는 명령을 실행합니다.
-# CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
 CMD ["gunicorn", "core.wsgi:application", "--bind", "0.0.0.0:8000"]
-


### PR DESCRIPTION
Dockerfile 에 몇가지를 추가 했습니다.
이제 docker compose up 하면 venv 로서 가상 환경이 실행
향후 패키지 설치 시, 해당 도커 내 가상환경 내부에서 pip 를 실행하도록 설정
불필요한 패키지를 빌드 후 삭제하도록 설정 (gcc, musl-dev) (용량)
django-user 라는 비권한 사용자 생성 및, 이 사용자로 전환하도록 설정 (보안)

일단 build 후 up 해보니 에러는 표시되지 않았습니다. develop 로 푸시 해 둘까요?
가장 눈에 띄는 변동 사항: 
이제 VSCode 실행 할 때마다 venv 안 하셔도 됩니다.
묘했던 경로들이, 이제 명확하게 도커로 전부 향하고 있습니다. (패키지 설치, 가상환경)